### PR TITLE
Replace the crypto module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "oauth-1.0a": "^2.0.0",
-    "request": "^2.75.0"
+    "request": "^2.75.0",
+    "create-hmac": "^1.1.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Add the "create-hmac" dependency to the project, replacing the crypto, that was deprecated https://www.npmjs.com/package/crypto and replaced by a native node module.